### PR TITLE
Bump deployment target to iOS/macCatalyst 18.6

### DIFF
--- a/tools/ci_build/github/apple/goodnotes_maccatalyst_build_settings.json
+++ b/tools/ci_build/github/apple/goodnotes_maccatalyst_build_settings.json
@@ -26,17 +26,17 @@
             "--ios",
             "--use_xcode",
             "--use_xnnpack",
-            "--apple_deploy_target=15.1"
+            "--apple_deploy_target=18.6"
         ],
         "iphonesimulator": [
             "--ios",
             "--use_xcode",
             "--use_xnnpack",
-            "--apple_deploy_target=15.1"
+            "--apple_deploy_target=18.6"
         ],
         "macabi": [
             "--macos=Catalyst",
-            "--apple_deploy_target=14.0",
+            "--apple_deploy_target=18.6",
             "--cmake_extra_defines=FETCHCONTENT_TRY_FIND_PACKAGE_MODE=NEVER"
         ]
     }


### PR DESCRIPTION
GoodNotes only supports iOS 18.6+. Apple validates that the MinimumOSVersion in the framework Info.plist matches what the app declares. The deploy target flows from --apple_deploy_target through cmake/Info.plist.in (@CMAKE_OSX_DEPLOYMENT_TARGET@) into each framework slice's Info.plist, and from there into the xcframework root Info.plist via xcodebuild -create-xcframework.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


